### PR TITLE
v.1.6

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@ v.1.6
  - Initial Ubuntu 20.04 (Focal) support
  - Change theme in real time when set to system theme
  - Support up/down arrow keys and backspace for moving between fields when adding new values
+ - Added a way to only navigate between dates with data
 
 v.1.5
  - Update French translations (Thanks Anne017)

--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 v.1.6
  - Initial Ubuntu 20.04 (Focal) support
  - Change theme in real time when set to system theme
+ - Support up/down arrow keys and backspace for moving between fields when adding new values
 
 v.1.5
  - Update French translations (Thanks Anne017)

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+v.1.6
+ - Initial Ubuntu 20.04 (Focal) support
+ - Change theme in real time when set to system theme
+
 v.1.5
  - Update French translations (Thanks Anne017)
  - Updated web version URL

--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,7 @@ v.1.6
  - Change theme in real time when set to system theme
  - Support up/down arrow keys and backspace for moving between fields when adding new values
  - Added a way to only navigate between dates with data
+ - Fix label sizing of the date in list page
 
 v.1.5
  - Update French translations (Thanks Anne017)

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -9,7 +9,7 @@
             "desktop": "subaybay/subaybay.desktop"
         }
     },
-    "version": "1.5",
+    "version": "1.6",
     "maintainer": "Kugi Eusebio <kugi_eusebio@protonmail.com>",
     "framework": "ubuntu-sdk-16.04.5"
 }

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-30 11:39+0000\n"
+"POT-Creation-Date: 2022-12-30 16:42+0000\n"
 "PO-Revision-Date: 2021-12-30 15:53+0100\n"
 "Last-Translator: Anne017\n"
 "Language-Team: \n"
@@ -121,13 +121,13 @@ msgid "Date and time pickers"
 msgstr "Sélecteurs de date et d'heure"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/MainPage.qml:23
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:142
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:171
 msgid "Switch Profile"
 msgstr "Changer de profil"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/MainPage.qml:34
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/NewEntrySelectionPopup.qml:93
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:95
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:114
 msgid "New Entry"
 msgstr "Nouvelle entrée"
 
@@ -136,7 +136,7 @@ msgid "Updating data"
 msgstr "Mise à jour des données"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/MainPage.qml:62
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:306
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:335
 msgid "Please wait"
 msgstr "Veuillez patienter"
 
@@ -194,17 +194,17 @@ msgid "Profile deleted"
 msgstr "Profil supprimé"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ProfilesPopup.qml:30
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:192
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:221
 msgid "Error deleting"
 msgstr "Erreur lors de la suppression"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ProfilesPopup.qml:40
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:153
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:182
 msgid "Edit"
 msgstr "Modifier"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ProfilesPopup.qml:51
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:164
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:193
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -223,44 +223,53 @@ msgstr "Textes en couleur"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:78
 #, fuzzy
-msgid "No previous data"
+msgid "No older data"
 msgstr "Aucune donnée"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:106
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:87
+#, fuzzy
+msgid "No newer data"
+msgstr "Aucune donnée"
+
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:125
 msgid "View Today"
 msgstr "Afficher aujourd'hui"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:118
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:137
 msgid "View Last Data"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:130
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:148
+msgid "View Next Data"
+msgstr ""
+
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:159
 msgid "Sort"
 msgstr "Trier"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:180
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:209
 msgid "Delete this value?"
 msgstr "Supprimer cette valeur ?"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:182
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:211
 msgid "Delete all with the same date/time"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:189
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:218
 msgid "Value deleted"
 msgstr "Valeur supprimée"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:252
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:281
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/components/valueslistpage/CriteriaPopup.qml:65
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:55
 msgid "All"
 msgstr "Tout"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:304
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:333
 msgid "No data"
 msgstr "Aucune donnée"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:305
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:334
 msgid "Loading data"
 msgstr "Chargement des données"
 
@@ -336,7 +345,7 @@ msgid "Total"
 msgstr "Total"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/components/valueslistpage/SummaryValuesDelegate.qml:65
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:268
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:271
 msgid "Average"
 msgstr "Moyenne"
 
@@ -675,48 +684,48 @@ msgstr ""
 msgid "Body weight"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:253
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:256
 msgid "Today's Total"
 msgstr "Total pour aujourd'hui"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:255
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:258
 msgid "This week's Total"
 msgstr "Total pour cette semaine"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:257
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:260
 msgid "Recent Total"
 msgstr "Total récent"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:262
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:265
 msgid "Today's Average"
 msgstr "Moyenne pour aujourd'hui"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:264
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:267
 msgid "This Week's Average"
 msgstr "Moyenne pour cette semaine"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:266
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:269
 #, fuzzy
 msgid "This Month's Average"
 msgstr "Moyenne pour cette semaine"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:271
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:274
 msgid "Recent Daily Average"
 msgstr "Moyenne journalière récente"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:273
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:276
 msgid "Recent Average"
 msgstr "Moyenne récente"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:282
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:285
 msgid "Highest Today"
 msgstr "La plus haute aujourd'hui"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:284
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:287
 msgid "Highest This Week"
 msgstr "La plus haute cette semaine"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:286
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:289
 msgid "Highest Recently"
 msgstr "La plus haute récemment"
 
@@ -765,9 +774,13 @@ msgstr "Plus vieux"
 msgid "In The Future"
 msgstr "Dans le futur"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/aarch64-linux-gnu/app/subaybay/subaybay.desktop.h:1
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/x86_64-linux-gnu/app/subaybay/subaybay.desktop.h:1
 msgid "Subaybay"
 msgstr "Subaybay"
+
+#, fuzzy
+#~ msgid "No previous data"
+#~ msgstr "Aucune donnée"
 
 #, fuzzy
 #~ msgid ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-23 14:54+0000\n"
+"POT-Creation-Date: 2022-12-30 09:55+0000\n"
 "PO-Revision-Date: 2021-12-30 15:53+0100\n"
 "Last-Translator: Anne017\n"
 "Language-Team: \n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:114
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:119
 msgid "No monitoring data for today"
 msgstr "Pas de données de suivi pour aujourd'hui"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:202
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:207
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:11
 msgid "Settings"
 msgstr "Paramètres"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:203
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:208
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:9
 msgid "About"
 msgstr "À propos"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:204
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:209
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:14
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/HelpPage.qml:28
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:16
 msgid "Help"
 msgstr "Aide"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:229
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:234
 msgid "Menu"
 msgstr "Menu"
 
@@ -765,7 +765,7 @@ msgstr "Plus vieux"
 msgid "In The Future"
 msgstr "Dans le futur"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/x86_64-linux-gnu/app/subaybay/subaybay.desktop.h:1
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/aarch64-linux-gnu/app/subaybay/subaybay.desktop.h:1
 msgid "Subaybay"
 msgstr "Subaybay"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-30 16:42+0000\n"
+"POT-Creation-Date: 2022-12-30 17:03+0000\n"
 "PO-Revision-Date: 2021-12-30 15:53+0100\n"
 "Last-Translator: Anne017\n"
 "Language-Team: \n"
@@ -774,7 +774,7 @@ msgstr "Plus vieux"
 msgid "In The Future"
 msgstr "Dans le futur"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/x86_64-linux-gnu/app/subaybay/subaybay.desktop.h:1
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/aarch64-linux-gnu/app/subaybay/subaybay.desktop.h:1
 msgid "Subaybay"
 msgstr "Subaybay"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-30 09:55+0000\n"
+"POT-Creation-Date: 2022-12-30 11:39+0000\n"
 "PO-Revision-Date: 2021-12-30 15:53+0100\n"
 "Last-Translator: Anne017\n"
 "Language-Team: \n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:119
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:118
 msgid "No monitoring data for today"
 msgstr "Pas de données de suivi pour aujourd'hui"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:207
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:206
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:11
 msgid "Settings"
 msgstr "Paramètres"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:208
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:207
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:9
 msgid "About"
 msgstr "À propos"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:209
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:208
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:14
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/HelpPage.qml:28
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:16
 msgid "Help"
 msgstr "Aide"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:234
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:233
 msgid "Menu"
 msgstr "Menu"
 
@@ -171,7 +171,7 @@ msgstr "Annuler"
 msgid "All entries with the same date/time will be updated"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/NewEntryPopup.qml:303
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/NewEntryPopup.qml:304
 msgid "Comments/Observations"
 msgstr "Commentaires/Observations"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-23 14:54+0000\n"
+"POT-Creation-Date: 2022-12-30 09:55+0000\n"
 "PO-Revision-Date: 2021-08-02 13:36+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:114
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:119
 msgid "No monitoring data for today"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:202
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:207
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:11
 msgid "Settings"
 msgstr "Instellingen"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:203
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:208
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:9
 msgid "About"
 msgstr "Over"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:204
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:209
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:14
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/HelpPage.qml:28
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:16
 msgid "Help"
 msgstr "Hulp"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:229
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:234
 msgid "Menu"
 msgstr "Menu"
 
@@ -747,7 +747,7 @@ msgstr "Ouder"
 msgid "In The Future"
 msgstr "Toekomstig"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/x86_64-linux-gnu/app/subaybay/subaybay.desktop.h:1
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/aarch64-linux-gnu/app/subaybay/subaybay.desktop.h:1
 msgid "Subaybay"
 msgstr "Subaybay"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-30 09:55+0000\n"
+"POT-Creation-Date: 2022-12-30 11:39+0000\n"
 "PO-Revision-Date: 2021-08-02 13:36+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:119
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:118
 msgid "No monitoring data for today"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:207
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:206
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:11
 msgid "Settings"
 msgstr "Instellingen"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:208
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:207
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:9
 msgid "About"
 msgstr "Over"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:209
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:208
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:14
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/HelpPage.qml:28
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:16
 msgid "Help"
 msgstr "Hulp"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:234
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:233
 msgid "Menu"
 msgstr "Menu"
 
@@ -173,7 +173,7 @@ msgstr "Annuleren"
 msgid "All entries with the same date/time will be updated"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/NewEntryPopup.qml:303
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/NewEntryPopup.qml:304
 msgid "Comments/Observations"
 msgstr "Opmerkingen/Waarnemingen"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-30 11:39+0000\n"
+"POT-Creation-Date: 2022-12-30 16:42+0000\n"
 "PO-Revision-Date: 2021-08-02 13:36+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -123,13 +123,13 @@ msgid "Date and time pickers"
 msgstr ""
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/MainPage.qml:23
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:142
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:171
 msgid "Switch Profile"
 msgstr "Ander profiel kiezen"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/MainPage.qml:34
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/NewEntrySelectionPopup.qml:93
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:95
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:114
 msgid "New Entry"
 msgstr "Nieuw item"
 
@@ -138,7 +138,7 @@ msgid "Updating data"
 msgstr "Bezig met bijwerken…"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/MainPage.qml:62
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:306
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:335
 msgid "Please wait"
 msgstr "Even geduld…"
 
@@ -196,17 +196,17 @@ msgid "Profile deleted"
 msgstr "Het profiel is verwijderd"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ProfilesPopup.qml:30
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:192
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:221
 msgid "Error deleting"
 msgstr "Het verwijderen is mislukt"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ProfilesPopup.qml:40
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:153
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:182
 msgid "Edit"
 msgstr "Aanpassen"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ProfilesPopup.qml:51
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:164
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:193
 msgid "Delete"
 msgstr "Verwijderen"
 
@@ -225,44 +225,53 @@ msgstr "Gekleurde tekst"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:78
 #, fuzzy
-msgid "No previous data"
+msgid "No older data"
 msgstr "Geen gegevens"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:106
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:87
+#, fuzzy
+msgid "No newer data"
+msgstr "Geen gegevens"
+
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:125
 msgid "View Today"
 msgstr "Ga naar vandaag"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:118
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:137
 msgid "View Last Data"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:130
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:148
+msgid "View Next Data"
+msgstr ""
+
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:159
 msgid "Sort"
 msgstr "Sorteren"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:180
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:209
 msgid "Delete this value?"
 msgstr "Weet je zeker dat je deze waarde wilt verwijderen?"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:182
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:211
 msgid "Delete all with the same date/time"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:189
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:218
 msgid "Value deleted"
 msgstr "De waarde is verwijderd"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:252
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:281
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/components/valueslistpage/CriteriaPopup.qml:65
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:55
 msgid "All"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:304
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:333
 msgid "No data"
 msgstr "Geen gegevens"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:305
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:334
 msgid "Loading data"
 msgstr "Bezig met laden van gegevens…"
 
@@ -337,7 +346,7 @@ msgid "Total"
 msgstr "Totaal"
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/components/valueslistpage/SummaryValuesDelegate.qml:65
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:268
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:271
 msgid "Average"
 msgstr "Gemiddeld"
 
@@ -657,48 +666,48 @@ msgstr ""
 msgid "Body weight"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:253
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:256
 msgid "Today's Total"
 msgstr "Totaal (vandaag)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:255
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:258
 msgid "This week's Total"
 msgstr "Totaal (afgelopen week)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:257
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:260
 msgid "Recent Total"
 msgstr "Totaal (recent)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:262
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:265
 msgid "Today's Average"
 msgstr "Gemiddelde (vandaag)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:264
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:267
 msgid "This Week's Average"
 msgstr "Gemiddelde (afgelopen week)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:266
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:269
 #, fuzzy
 msgid "This Month's Average"
 msgstr "Gemiddelde (afgelopen week)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:271
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:274
 msgid "Recent Daily Average"
 msgstr "Dagelijks gemiddelde (recent)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:273
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:276
 msgid "Recent Average"
 msgstr "Gemiddelde (recent)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:282
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:285
 msgid "Highest Today"
 msgstr "Hoogste (vandaag)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:284
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:287
 msgid "Highest This Week"
 msgstr "Hoogste (deze week)"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:286
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:289
 msgid "Highest Recently"
 msgstr "Hoogste (recent)"
 
@@ -747,9 +756,13 @@ msgstr "Ouder"
 msgid "In The Future"
 msgstr "Toekomstig"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/aarch64-linux-gnu/app/subaybay/subaybay.desktop.h:1
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/x86_64-linux-gnu/app/subaybay/subaybay.desktop.h:1
 msgid "Subaybay"
 msgstr "Subaybay"
+
+#, fuzzy
+#~ msgid "No previous data"
+#~ msgstr "Geen gegevens"
 
 #, fuzzy
 #~ msgid ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-30 16:42+0000\n"
+"POT-Creation-Date: 2022-12-30 17:03+0000\n"
 "PO-Revision-Date: 2021-08-02 13:36+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -756,7 +756,7 @@ msgstr "Ouder"
 msgid "In The Future"
 msgstr "Toekomstig"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/x86_64-linux-gnu/app/subaybay/subaybay.desktop.h:1
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/aarch64-linux-gnu/app/subaybay/subaybay.desktop.h:1
 msgid "Subaybay"
 msgstr "Subaybay"
 

--- a/po/subaybay.kugiigi.pot
+++ b/po/subaybay.kugiigi.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-30 16:42+0000\n"
+"POT-Creation-Date: 2022-12-30 17:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -706,6 +706,6 @@ msgstr ""
 msgid "In The Future"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/x86_64-linux-gnu/app/subaybay/subaybay.desktop.h:1
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/aarch64-linux-gnu/app/subaybay/subaybay.desktop.h:1
 msgid "Subaybay"
 msgstr ""

--- a/po/subaybay.kugiigi.pot
+++ b/po/subaybay.kugiigi.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-30 09:55+0000\n"
+"POT-Creation-Date: 2022-12-30 11:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,28 +17,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:119
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:118
 msgid "No monitoring data for today"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:207
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:206
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:11
 msgid "Settings"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:208
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:207
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:9
 msgid "About"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:209
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:208
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:14
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/HelpPage.qml:28
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:16
 msgid "Help"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:234
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:233
 msgid "Menu"
 msgstr ""
 
@@ -169,7 +169,7 @@ msgstr ""
 msgid "All entries with the same date/time will be updated"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/NewEntryPopup.qml:303
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/NewEntryPopup.qml:304
 msgid "Comments/Observations"
 msgstr ""
 

--- a/po/subaybay.kugiigi.pot
+++ b/po/subaybay.kugiigi.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-30 11:39+0000\n"
+"POT-Creation-Date: 2022-12-30 16:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -119,13 +119,13 @@ msgid "Date and time pickers"
 msgstr ""
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/MainPage.qml:23
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:142
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:171
 msgid "Switch Profile"
 msgstr ""
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/MainPage.qml:34
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/NewEntrySelectionPopup.qml:93
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:95
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:114
 msgid "New Entry"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid "Updating data"
 msgstr ""
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/MainPage.qml:62
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:306
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:335
 msgid "Please wait"
 msgstr ""
 
@@ -192,17 +192,17 @@ msgid "Profile deleted"
 msgstr ""
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ProfilesPopup.qml:30
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:192
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:221
 msgid "Error deleting"
 msgstr ""
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ProfilesPopup.qml:40
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:153
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:182
 msgid "Edit"
 msgstr ""
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ProfilesPopup.qml:51
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:164
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:193
 msgid "Delete"
 msgstr ""
 
@@ -220,44 +220,52 @@ msgid "Colored texts"
 msgstr ""
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:78
-msgid "No previous data"
+msgid "No older data"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:106
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:87
+msgid "No newer data"
+msgstr ""
+
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:125
 msgid "View Today"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:118
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:137
 msgid "View Last Data"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:130
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:148
+msgid "View Next Data"
+msgstr ""
+
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:159
 msgid "Sort"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:180
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:209
 msgid "Delete this value?"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:182
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:211
 msgid "Delete all with the same date/time"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:189
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:218
 msgid "Value deleted"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:252
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:281
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/components/valueslistpage/CriteriaPopup.qml:65
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:55
 msgid "All"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:304
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:333
 msgid "No data"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:305
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/ValuesListPage.qml:334
 msgid "Loading data"
 msgstr ""
 
@@ -332,7 +340,7 @@ msgid "Total"
 msgstr ""
 
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/components/valueslistpage/SummaryValuesDelegate.qml:65
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:268
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:271
 msgid "Average"
 msgstr ""
 
@@ -609,47 +617,47 @@ msgstr ""
 msgid "Body weight"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:253
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:256
 msgid "Today's Total"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:255
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:258
 msgid "This week's Total"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:257
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:260
 msgid "Recent Total"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:262
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:265
 msgid "Today's Average"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:264
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:267
 msgid "This Week's Average"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:266
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:269
 msgid "This Month's Average"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:271
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:274
 msgid "Recent Daily Average"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:273
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:276
 msgid "Recent Average"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:282
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:285
 msgid "Highest Today"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:284
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:287
 msgid "Highest This Week"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:286
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/library/dataUtils.js:289
 msgid "Highest Recently"
 msgstr ""
 
@@ -698,6 +706,6 @@ msgstr ""
 msgid "In The Future"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/aarch64-linux-gnu/app/subaybay/subaybay.desktop.h:1
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/x86_64-linux-gnu/app/subaybay/subaybay.desktop.h:1
 msgid "Subaybay"
 msgstr ""

--- a/po/subaybay.kugiigi.pot
+++ b/po/subaybay.kugiigi.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-23 14:54+0000\n"
+"POT-Creation-Date: 2022-12-30 09:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,28 +17,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:114
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:119
 msgid "No monitoring data for today"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:202
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:207
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:11
 msgid "Settings"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:203
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:208
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:9
 msgid "About"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:204
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:209
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/AboutPage.qml:14
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/HelpPage.qml:28
 #: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/ui/SettingsPage.qml:16
 msgid "Help"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:229
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/subaybay/Main.qml:234
 msgid "Menu"
 msgstr ""
 
@@ -698,6 +698,6 @@ msgstr ""
 msgid "In The Future"
 msgstr ""
 
-#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/x86_64-linux-gnu/app/subaybay/subaybay.desktop.h:1
+#: /home/kugiigi/Documents/Development/Subaybay/subaybay-app/build/aarch64-linux-gnu/app/subaybay/subaybay.desktop.h:1
 msgid "Subaybay"
 msgstr ""

--- a/subaybay/Main.qml
+++ b/subaybay/Main.qml
@@ -19,10 +19,15 @@ ApplicationWindow {
     id: mainView
 
     readonly property QtObject drawer: drawerLoader.item
-    readonly property string current_version: "1.5"
+    readonly property string current_version: "1.6"
     readonly property var suruTheme: switch(settings.currentTheme) {
             case "System":
-                undefined
+//~                 undefined
+                if (Theme.name == "Ubuntu.Components.Themes.SuruDark") {
+                    Suru.Dark
+                } else {
+                    Suru.Light
+                }
                 break
             case "Ambiance":
                 Suru.Light

--- a/subaybay/Main.qml
+++ b/subaybay/Main.qml
@@ -22,7 +22,6 @@ ApplicationWindow {
     readonly property string current_version: "1.6"
     readonly property var suruTheme: switch(settings.currentTheme) {
             case "System":
-//~                 undefined
                 if (Theme.name == "Ubuntu.Components.Themes.SuruDark") {
                     Suru.Dark
                 } else {

--- a/subaybay/components/newentrypopup/NewEntryItem.qml
+++ b/subaybay/components/newentrypopup/NewEntryItem.qml
@@ -9,6 +9,7 @@ import "../../library/functions.js" as Functions
 ColumnLayout {
     id: newEntryItem
 
+    property int itemIndex
     property string itemId
     property alias title: titleLabel.text
     property alias fields: fieldsRepeater.model
@@ -22,7 +23,13 @@ ColumnLayout {
     function focusFirstField() {
         fieldsRepeater.itemAt(0).valueField.focus = true
     }
-    
+
+    function focusPrevious(item) {
+        var prevItem = item.nextItemInFocusChain(false)
+
+        prevItem.focus = true
+    }
+
     function focusNext(item) {
         var nextItem = item.nextItemInFocusChain(true)
 
@@ -65,6 +72,12 @@ ColumnLayout {
             Layout.fillWidth: true
             spacing: 10
 
+            function focusPrevious() {
+                if (!(newEntryItem.itemIndex == 0 && model.index == 0)) {
+                    newEntryItem.focusPrevious(this)
+                }
+            }
+
             CustomTextField {
                 id: valueTextField
                 
@@ -80,6 +93,13 @@ ColumnLayout {
                 font.pixelSize: 20
                 horizontalAlignment: TextInput.AlignHCenter
                 Keys.onReturnPressed: newEntryItem.focusNext(this)
+                Keys.onPressed: {
+                    if (event.key == Qt.Key_Backspace && valueTextField.text == "") {
+                        focusPrevious()
+                    }
+                }
+                Keys.onUpPressed: focusPrevious()
+                Keys.onDownPressed: newEntryItem.focusNext(this)
                 onFocusChanged: {
                     if (focus) {
                         var labelY = labelRow.mapToItem(flickable.contentItem, 0, 0).y

--- a/subaybay/components/valueslistpage/ValuesNavigationRow.qml
+++ b/subaybay/components/valueslistpage/ValuesNavigationRow.qml
@@ -61,14 +61,16 @@ RowLayout {
                     Layout.fillWidth: true
                     Layout.alignment: Qt.AlignBaseline
                     Suru.textLevel: Suru.HeadingTwo
+                    fontSizeMode: Text.HorizontalFit
                     font.pointSize: navigationRow.biggerDateLabel ? Suru.units.gu(2.5) : Suru.units.gu(2)
+                    minimumPointSize: navigationRow.biggerDateLabel ? Suru.units.gu(1.5) : Suru.units.gu(1)
                     font.italic: true
                     role: "date"
                 }
               
                 CustomLabel {
                     id: scopeLabel
-    
+
                     Layout.alignment: Qt.AlignBottom
                     Suru.textLevel: Suru.HeadingThree
                     text: valuesListPage.scope

--- a/subaybay/library/dataUtils.js
+++ b/subaybay/library/dataUtils.js
@@ -84,8 +84,11 @@ var dataUtils = dataUtils || (function (undefined) {
                 , itemValues: function(itemId, scope, dateFrom, dateTo) {
                     return Database.getItemValues(profile, itemId, scope, dateFrom, dateTo)
                 }
-                , mostRecentDate: function(itemId) {
-                    return Database.getMostRecentDate(profile, itemId)
+                , lastDateWithData: function(itemId, dateBase) {
+                    return Database.getDateWithData(false, profile, itemId, dateBase)
+                }
+                , nextDateWithData: function(itemId, dateBase) {
+                    return Database.getDateWithData(true, profile, itemId, dateBase)
                 }
                 , entryDateMultiple: function(entryDate, itemId) {
                     return Database.checkEntryDateMultiple(profile, entryDate, itemId)

--- a/subaybay/library/database.js
+++ b/subaybay/library/database.js
@@ -591,7 +591,7 @@ function checkProfileData(intProfileId) {
     return exists
 }
 
-function getMostRecentDate(intProfileId, txtItemId) {
+function getDateWithData(forward, intProfileId, txtItemId, txtDateBase) {
     var db = openDB()
     var rs = null
     var txtSelectStatement
@@ -601,14 +601,23 @@ function getMostRecentDate(intProfileId, txtItemId) {
     var lastDate
 
     db.transaction(function (tx) {
-        txtSelectStatement = "SELECT max((strftime('%Y-%m-%d %H:%M:%f', entry_date, 'localtime'))) as entry_date \
-                              FROM monitor_items_values"
         txtWhereStatement = "WHERE profile_id = ?"
+
+        if (forward) {
+            txtSelectStatement = "SELECT min((strftime('%Y-%m-%d %H:%M:%f', entry_date, 'localtime'))) as entry_date"
+            txtWhereStatement = txtWhereStatement + " AND date(monitor_items_values.entry_date, 'localtime') > date(?)"
+        } else {
+            txtSelectStatement = "SELECT max((strftime('%Y-%m-%d %H:%M:%f', entry_date, 'localtime'))) as entry_date"
+            txtWhereStatement = txtWhereStatement + " AND date(monitor_items_values.entry_date, 'localtime') < date(?)"
+        }
+
+        txtSelectStatement = txtSelectStatement + " FROM monitor_items_values"
+
         if (txtItemId !== "all") {
             txtWhereStatement = txtWhereStatement + " AND item_id = ?"
-            arrArgs = [intProfileId, txtItemId]
+            arrArgs = [intProfileId, txtDateBase, txtItemId]
         } else {
-            arrArgs = [intProfileId]
+            arrArgs = [intProfileId, txtDateBase]
         }
 
         txtFullStatement = txtSelectStatement + " " + txtWhereStatement

--- a/subaybay/ui/NewEntryPopup.qml
+++ b/subaybay/ui/NewEntryPopup.qml
@@ -278,6 +278,7 @@ CustomPopup {
                     Layout.leftMargin: 20
                     Layout.rightMargin: 20
 
+                    itemIndex: model.index
                     itemId: model.itemId
                     title: model.displayName + " *"
                     fields: model.fields
@@ -306,9 +307,20 @@ CustomPopup {
 
                 TextArea {
                     id: commentTextArea
-            
+
+                    function focusPrevious() {
+                        var prevItem = commentTextArea.nextItemInFocusChain(false)
+                        prevItem.focus = true
+                    }
+
                     Layout.fillWidth: true
                     font.pixelSize: 15
+                    Keys.onPressed: {
+                        if (event.key == Qt.Key_Backspace && commentTextArea.text == "") {
+                            focusPrevious()
+                        }
+                    }
+                    Keys.onUpPressed: focusPrevious()
                     onFocusChanged: {
                         if (focus) {
                             Functions.scrollToView(this, flickable, commentLabel.height + commentColumn.spacing, 0)

--- a/subaybay/ui/ValuesListPage.qml
+++ b/subaybay/ui/ValuesListPage.qml
@@ -23,7 +23,7 @@ BasePage {
     signal refresh
     signal itemDeleted
 
-    headerRightActions: [addAction, todayAction, lastDataAction, sortAction, profilesAction]
+    headerRightActions: [addAction, todayAction, lastDataAction, nextDataAction, sortAction, profilesAction]
     
     Connections {
         target: mainView.settings
@@ -71,11 +71,20 @@ BasePage {
     }
 
     function goToLastData() {
-        var lastDate = mainView.values.mostRecentDate(itemId)
+        var lastDate = mainView.values.lastDateWithData(itemId, currentDate)
         if (lastDate) {
             currentDate = lastDate
         } else {
-            tooltip.display(i18n.tr("No previous data"))
+            tooltip.display(i18n.tr("No older data"))
+        }
+    }
+
+    function goToNextData() {
+        var lastDate = mainView.values.nextDateWithData(itemId, currentDate)
+        if (lastDate) {
+            currentDate = lastDate
+        } else {
+            tooltip.display(i18n.tr("No newer data"))
         }
     }
 
@@ -87,6 +96,16 @@ BasePage {
     Shortcut {
         sequence: StandardKey.MoveToPreviousChar
         onActivated: previous()
+    }
+
+    Shortcut {
+        sequence: StandardKey.MoveToNextWord
+        onActivated: goToNextData()
+    }
+
+    Shortcut {
+        sequence: StandardKey.MoveToPreviousWord
+        onActivated: goToLastData()
     }
 
     BaseAction{
@@ -117,10 +136,20 @@ BasePage {
     
         text: i18n.tr("View Last Data")
         iconName: "go-previous"
-        enabled: dateViewPath.currentItem.count === 0
-    
+
         onTrigger:{
             goToLastData()
+        }
+    }
+
+    BaseAction{
+        id: nextDataAction
+    
+        text: i18n.tr("View Next Data")
+        iconName: "go-next"
+    
+        onTrigger:{
+            goToNextData()
         }
     }
 


### PR DESCRIPTION
 - Initial Ubuntu 20.04 (Focal) support
 - Change theme in real time when set to system theme
 - Support up/down arrow keys and backspace for moving between fields when adding new values
 - Added a way to only navigate between dates with data
 - Fix label sizing of the date in list page